### PR TITLE
Fix UIRequiredDeviceCapabilities to arm64 for unsupport less than 11

### DIFF
--- a/PyConJP/Support Files/Info.plist
+++ b/PyConJP/Support Files/Info.plist
@@ -31,7 +31,7 @@
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>armv64</string>
 	</array>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleDefault</string>


### PR DESCRIPTION
refs: 

### Motivation and Context
* http://starhoshi.hatenablog.com/entry/2018/01/09/014208

### Description
